### PR TITLE
fixed github links in about section and reset the form on back/home

### DIFF
--- a/scripts/controllers/homeController.js
+++ b/scripts/controllers/homeController.js
@@ -1,6 +1,7 @@
 (function(module) {
   var homeController = {};
   homeController.reveal = function() {
+    $('#zipentry').val('');
     $('.page-content').hide();
     $('#homepage').fadeIn();
   };

--- a/scripts/views/aboutView.js
+++ b/scripts/views/aboutView.js
@@ -1,6 +1,6 @@
 'use strict';
 
-$('#about').on('click', 'a', function() {
+$('#about').on('click', 'h2', function() {
   event.preventDefault();
   $('#about').css('top', '15%');
   $('article').hide();


### PR DESCRIPTION
Quick fixes:

github links were not working because of how the event handler was setup then modified. This is now fixed. All is well.

form value (#zipentry) will now be reset when hitting back or home. Yay.
